### PR TITLE
docs: Pi-AI provider 기본 스펙 초안 추가

### DIFF
--- a/docs/pi-ai-provider-spec.md
+++ b/docs/pi-ai-provider-spec.md
@@ -155,10 +155,21 @@ Potential toggle:
 
 ## 10) Test Plan
 
+### 10.1 Baseline for early integration tests
+
+For initial validation in local/dev environments, use **Codex OAuth** as the default baseline authentication path when testing shared orchestration behavior around provider switching and session handling.
+
+- Rationale: Codex OAuth is already used in the current environment and provides a stable control baseline.
+- Scope: This baseline is for integration sanity checks (session wiring, routing, command flow), not as a substitute for `pi-ai` auth tests.
+- Requirement: `pi-ai` provider itself must still be tested with its own credentials/API path before production use.
+
+### 10.2 Test checklist
+
 1. Unit tests for event mapping (`pi-ai response -> AgentEvent[]`)
 2. Session lifecycle tests (`create -> send -> close`)
 3. Error-path tests (auth failure, network timeout)
 4. Manual discord channel smoke test with provider switch
+5. Cross-check against Codex OAuth baseline behavior (turn lifecycle, stream completion, recoverable errors)
 
 ## 11) Open Questions
 


### PR DESCRIPTION
## 요약\nPi-AI provider 추가를 위한 기본 스펙 문서를 추가했습니다.\n\n## 포함 내용\n- 배경/목표/비목표\n- 타입 및 provider 구조 변경안\n- 이벤트 매핑/세션 동작\n- env 항목 제안\n- 롤아웃 단계(Phase 1~3)\n- 테스트 계획/오픈 질문/DoD\n\n문서 작성자 표기는 **yuna**로 반영했습니다.\n\n## 파일\n- 